### PR TITLE
Storage space fix

### DIFF
--- a/LiteDB/Engine/Disk/DiskService.cs
+++ b/LiteDB/Engine/Disk/DiskService.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using LiteDB.Utils;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -348,14 +349,16 @@ namespace LiteDB.Engine
             // can change file size
             var delete = _logFactory.Exists() && _logPool.Writer.Value.Length == 0;
 
-            // dispose Stream pools
-            _dataPool.Dispose();
-            _logPool.Dispose();
+            var tc = new TryCatch();
 
-            if (delete) _logFactory.Delete();
+            // dispose Stream pools
+            tc.Catch(() => _dataPool.Dispose());
+            tc.Catch(() => _logPool.Dispose());
+
+            if (delete) tc.Catch(() => _logFactory.Delete());
 
             // other disposes
-            _cache.Dispose();
+            tc.Catch(() => _cache.Dispose());
         }
     }
 }

--- a/LiteDB/Engine/Disk/DiskService.cs
+++ b/LiteDB/Engine/Disk/DiskService.cs
@@ -55,7 +55,15 @@ namespace LiteDB.Engine
             {
                 LOG($"creating new database: '{Path.GetFileName(_dataFactory.Name)}'", "DISK");
 
-                this.Initialize(_dataPool.Writer.Value, settings.Collation, settings.InitialSize);
+                try
+                {
+                    this.Initialize(_dataPool.Writer.Value, settings.Collation, settings.InitialSize);
+                }
+                catch (Exception ex)
+                {
+                    LOG($"Error while initializing DiskService: {ex.Message}", "ERROR");
+                    throw;
+                }
             }
 
             // if not readonly, force open writable datafile

--- a/LiteDB/Engine/Services/RebuildService.cs
+++ b/LiteDB/Engine/Services/RebuildService.cs
@@ -52,37 +52,39 @@ namespace LiteDB.Engine
                 reader.Open();
 
                 // open new engine to recive all data readed from FileReader
-                using var engine = new LiteEngine(new EngineSettings
+                using (var engine = new LiteEngine(new EngineSettings
                 {
                     Filename = tempFilename,
                     Collation = options.Collation,
                     Password = options.Password,
-                });
-                // copy all database to new Log file with NO checkpoint during all rebuild
-                engine.Pragma(Pragmas.CHECKPOINT, 0);
-
-                // rebuild all content from reader into new engine
-                engine.RebuildContent(reader);
-
-                // insert error report
-                if (options.IncludeErrorReport && options.Errors.Count > 0)
+                }))
                 {
-                    var report = options.GetErrorReport();
+                    // copy all database to new Log file with NO checkpoint during all rebuild
+                    engine.Pragma(Pragmas.CHECKPOINT, 0);
 
-                    engine.Insert("_rebuild_errors", report, BsonAutoId.Int32);
+                    // rebuild all content from reader into new engine
+                    engine.RebuildContent(reader);
+
+                    // insert error report
+                    if (options.IncludeErrorReport && options.Errors.Count > 0)
+                    {
+                        var report = options.GetErrorReport();
+
+                        engine.Insert("_rebuild_errors", report, BsonAutoId.Int32);
+                    }
+
+                    // update pragmas
+                    var pragmas = reader.GetPragmas();
+
+                    engine.Pragma(Pragmas.CHECKPOINT, pragmas[Pragmas.CHECKPOINT]);
+                    engine.Pragma(Pragmas.TIMEOUT, pragmas[Pragmas.TIMEOUT]);
+                    engine.Pragma(Pragmas.LIMIT_SIZE, pragmas[Pragmas.LIMIT_SIZE]);
+                    engine.Pragma(Pragmas.UTC_DATE, pragmas[Pragmas.UTC_DATE]);
+                    engine.Pragma(Pragmas.USER_VERSION, pragmas[Pragmas.USER_VERSION]);
+
+                    // after rebuild, copy log bytes into data file
+                    engine.Checkpoint();
                 }
-
-                // update pragmas
-                var pragmas = reader.GetPragmas();
-
-                engine.Pragma(Pragmas.CHECKPOINT, pragmas[Pragmas.CHECKPOINT]);
-                engine.Pragma(Pragmas.TIMEOUT, pragmas[Pragmas.TIMEOUT]);
-                engine.Pragma(Pragmas.LIMIT_SIZE, pragmas[Pragmas.LIMIT_SIZE]);
-                engine.Pragma(Pragmas.UTC_DATE, pragmas[Pragmas.UTC_DATE]);
-                engine.Pragma(Pragmas.USER_VERSION, pragmas[Pragmas.USER_VERSION]);
-
-                // after rebuild, copy log bytes into data file
-                engine.Checkpoint();
             }
 
             // if log file exists, rename as backup file

--- a/LiteDB/Engine/Services/RebuildService.cs
+++ b/LiteDB/Engine/Services/RebuildService.cs
@@ -51,14 +51,15 @@ namespace LiteDB.Engine
                 // open file reader and ready to import to new temp engine instance
                 reader.Open();
 
-                // open new engine to recive all data readed from FileReader
-                using (var engine = new LiteEngine(new EngineSettings
+                try
                 {
-                    Filename = tempFilename,
-                    Collation = options.Collation,
-                    Password = options.Password,
-                }))
-                {
+                    // open new engine to recive all data readed from FileReader
+                    using var engine = new LiteEngine(new EngineSettings
+                    {
+                        Filename = tempFilename,
+                        Collation = options.Collation,
+                        Password = options.Password,
+                    });
                     // copy all database to new Log file with NO checkpoint during all rebuild
                     engine.Pragma(Pragmas.CHECKPOINT, 0);
 
@@ -84,6 +85,11 @@ namespace LiteDB.Engine
 
                     // after rebuild, copy log bytes into data file
                     engine.Checkpoint();
+                }
+                catch (Exception)
+                {
+                    File.Delete(tempFilename);
+                    throw;
                 }
             }
 


### PR DESCRIPTION
Fixes multiple bugs that happen when there is no storage left on the device and System.IO.IOException: There is not enough space on the disk. is thrown:

DiskService not disposing itself in case of an exception
DiskReader never being disposed if an exception was thrown during transaction disposal. It led to log stream never returning to the pool and never closing a handle to the log file resulting in RebuildService failing to rename the log file, as well as TransactionMonitor not disposing the rest of the transactions
Fixes https://github.com/litedb-org/LiteDB/issues/2286
Fixes https://github.com/litedb-org/LiteDB/issues/2614
Fixes https://github.com/litedb-org/LiteDB/issues/2615