### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
 name: publish
+permissions:
+  contents: read
 on:
   workflow_dispatch: # Allow running the workflow manually from the GitHub UI
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/PlainBytes/PlainBytes.LiteDB/security/code-scanning/4](https://github.com/PlainBytes/PlainBytes.LiteDB/security/code-scanning/4)

To resolve this issue in the safest and least-intrusive manner, you should add a top-level `permissions` block near the top of the workflow file (`.github/workflows/publish.yml`). This will apply minimal permissions (usually `contents: read`) to all jobs, unless a specific job needs broader permissions for a legitimate reason (e.g. to create releases or PRs). Since none of the jobs shown require actions such as creating releases or writing to the repo (NuGet publishing uses a secret), it is appropriate to set:

```yaml
permissions:
  contents: read
```

If later some jobs require more, you can override at the job level, but this is not currently indicated in the code you provided. This block should be placed immediately after the `name:` line and before any `on:` or other sections.

**Files/regions/lines to change:**  
- Edit file: `.github/workflows/publish.yml`  
- Insert the recommended `permissions` block after the `name:` line (`line 3`).

No new methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
